### PR TITLE
Opt smoothing

### DIFF
--- a/simnibs/examples/optimization/tms_opt_refined.m
+++ b/simnibs/examples/optimization/tms_opt_refined.m
@@ -27,5 +27,7 @@ tms_opt.pos_ydir = [-56.4, -22.2, 96.0];
 tms_opt.search_angle = 90;
 % Change the angular resolution
 tms_opt.angle_resolution = 15;
+% Increase smoothing steps for uneven skin surface
+tms_opt.smooth = 20;
 
 run_simnibs(tms_opt)

--- a/simnibs/examples/optimization/tms_opt_refined.py
+++ b/simnibs/examples/optimization/tms_opt_refined.py
@@ -28,7 +28,8 @@ tms_opt.pos_ydir = [-56.4, -22.2, 96.0]
 tms_opt.search_angle = 90
 # Change the angular resolution
 tms_opt.angle_resolution = 15
-
+# Increase smoothing steps for uneven skin surface
+tms_opt.smooth = 20
 
 # Run optimization
 tms_opt.run()

--- a/simnibs/optimization/opt_struct.py
+++ b/simnibs/optimization/opt_struct.py
@@ -124,6 +124,7 @@ class TMSoptimize():
         self.spatial_resolution = 5
         self.search_angle = 360
         self.angle_resolution = 30
+        self.smooth = 1
 
         self.open_in_gmsh = True
         self.solver_options = ''
@@ -330,7 +331,8 @@ class TMSoptimize():
             distance=self.distance, radius=self.search_radius,
             resolution_pos=self.spatial_resolution,
             resolution_angle=self.angle_resolution,
-            angle_limits=[-self.search_angle/2, self.search_angle/2]
+            angle_limits=[-self.search_angle/2, self.search_angle/2],
+            smooth=self.smooth
         )
         cond = SimuList.cond2elmdata(self)
         didt_list = [self.didt for i in pos_matrices]

--- a/simnibs/optimization/optimize_tms.py
+++ b/simnibs/optimization/optimize_tms.py
@@ -8,7 +8,7 @@ Adapted by Guilherme Saturnino, 2019
 import numpy as np
 
 
-def _create_grid(mesh, pos, distance, radius, resolution_pos):
+def _create_grid(mesh, pos, distance, radius, resolution_pos, smooth=1):
     ''' Creates a position grid '''
     # extract ROI
     msh_surf = mesh.crop_mesh(elm_type=2)
@@ -38,7 +38,7 @@ def _create_grid(mesh, pos, distance, radius, resolution_pos):
     # project grid-points to skin-surface
     coords_mapped = []
     coords_normals = []
-    normals_roi = msh_roi.triangle_normals(smooth=1)
+    normals_roi = msh_roi.triangle_normals(smooth=smooth)
     for i, c in enumerate(coords_plane):
         # Query points inside/outside the surface
         q1 = c + 1e2 * vh[:, 2]
@@ -73,7 +73,7 @@ def _rotate_system(R, angle_limits, angle_res):
 
 
 def get_opt_grid(mesh, pos, handle_direction_ref=None, distance=1., radius=20,
-                 resolution_pos=1, resolution_angle=20, angle_limits=None):
+                 resolution_pos=1, resolution_angle=20, angle_limits=None, smooth=1):
     """ Determine the coil positions and orientations for bruteforce TMS optimization
 
     Parameters
@@ -82,7 +82,7 @@ def get_opt_grid(mesh, pos, handle_direction_ref=None, distance=1., radius=20,
         Simnibs mesh object
     pos: ndarray
         Coordinates (x, y, z) of reference position
-    handle_direction_ref (optinal): list of float or np.ndarray
+    handle_direction_ref: list of float or np.ndarray (optional)
         Vector of handle prolongation direction, in relation to "pos". (Default: do
         not select a handle direction and scan rotations from -180 to 180)
     distance: float or None
@@ -96,6 +96,8 @@ def get_opt_grid(mesh, pos, handle_direction_ref=None, distance=1., radius=20,
         Resolution in deg of the coil positions in the region of interest (Default: 20)
     angle_limits: list of float or None
         Range of angles to get coil rotations for (Default: [-180, 180])
+    smooth: int (optional)
+        Smoothing steps of skin-surface smoothing for coil z-axis orientation. Default: 1
 
     Returns
     -------
@@ -104,7 +106,7 @@ def get_opt_grid(mesh, pos, handle_direction_ref=None, distance=1., radius=20,
     """
     # creates the spatial grid
     coords_mapped, coords_normals = _create_grid(
-        mesh, pos, distance, radius, resolution_pos)
+        mesh, pos, distance, radius, resolution_pos, smooth)
     
     # Determines the seed y direction
     if handle_direction_ref is None:


### PR DESCRIPTION
This implements an option to increase smoothing of the coil z-axis as proposed (#42 ) by @oulap to circumvent skewed coil positions due to uneven skin surfaces.

Default behavior is unchanged.
A `smooth`parameter is added to `TMSoptimize._init()`, which is used to define the smoothing steps via `optimize_tms.get_opt_grid()` and `optimize_tms._create_grid()`