### PR TITLE
_direct_optimize: keep_hdf5

### DIFF
--- a/simnibs/optimization/opt_struct.py
+++ b/simnibs/optimization/opt_struct.py
@@ -481,7 +481,13 @@ class TMSoptimize():
             self.tissues
         )
 
-    def _direct_optimize(self, cond_field, target_region, pos_matrices, cpus):
+    def _direct_optimize(self, cond_field, target_region, pos_matrices, cpus, keep_hdf5=False):
+        """
+        Parameters:
+        -----------
+        keep_hdf5 : bool (optional)
+            Keep .hdf5 file with target E for all coil positions. Default: False.
+        """
         didt_list = [self.didt for i in pos_matrices]
         fn_hdf5 = os.path.join(self.pathfem, self._name_hdf5())
         if os.path.isfile(fn_hdf5):
@@ -527,7 +533,8 @@ class TMSoptimize():
         # Read the fields
         with h5py.File(fn_hdf5, 'a') as f:
             E_roi = f[dataset][:]
-        os.remove(fn_hdf5)
+        if not keep_hdf5:
+            os.remove(fn_hdf5)
             
         return E_roi
 


### PR DESCRIPTION
I added an argument to `simnibs.optimization.opt_struct._direct_optimize()` to allow keeping the target |E| for all coil positions computed during the optimization. Default behavior does not change (=remove .hdf5).

We need this to quantify the set of coil positions tested during the optimization procedure.

Bests,
Ole