### PR TITLE
Fixing a small regression in tms_many_simulations: The HDF5 file containing the efield simualtion results is now explicitly opened in append mode.

### DIFF
--- a/simnibs/simulation/fem.py
+++ b/simnibs/simulation/fem.py
@@ -1581,7 +1581,7 @@ def tms_many_simulations(
                 out_field = out_field[0]
             if post_pro is not None:
                 out_field = post_pro(out_field)
-            with h5py.File(fn_hdf5) as f:
+            with h5py.File(fn_hdf5,'a') as f:
                 f[dataset][i] = out_field
 
     # Run in parallel


### PR DESCRIPTION
Hi!

When computing the efields sequentially in tms_many_simulations, the HDF5 file handle for storing the results was opened without a mode-parameter ('r','a','w') before, which since h5py v.3.0 results in a read-only handle instead of a writable/appendable handle.
Trying to store the results with the read-only file handle raised an exception: "*no write intent*".

From https://docs.h5py.org/en/stable/high/file.html :
> Changed in version 3.0: Files are now opened read-only by default. Earlier versions of h5py would pick different modes depending on the presence and permissions of the file.

I simply added the append-mode parameter.

Best,
Benjamin