### PR TITLE
Add support for Brainsight .txt file format v14, with more detailed NIfTI coordinate system names 

### DIFF
--- a/simnibs/_internal_resources/testing_files/nnav_testdata/brainsight/niiImage_niftialigned_q_coord_v14.txt
+++ b/simnibs/_internal_resources/testing_files/nnav_testdata/brainsight/niiImage_niftialigned_q_coord_v14.txt
@@ -1,0 +1,15 @@
+# Version: 14
+# Coordinate system: NIfTI:Q:Aligned
+# Created by: Brainsight 2.5.3
+# Units: millimetres, degrees, milliseconds, and microvolts
+# Encoding: UTF-8
+# Notes: Each column is delimited by a tab. Each value within a column is delimited by a semicolon.
+# Target Name	Loc. X	Loc. Y	Loc. Z	m0n0	m0n1	m0n2	m1n0	m1n1	m1n2	m2n0	m2n1	m2n2
+Trajectory 1	34.4660	26.1880	63.4670	-0.9368	0.0000	0.3499	0.0000	-1.0000	0.0000	0.3499	0.0000	0.9368
+Trajectory 2	39.4660	31.1880	63.4670	-0.9368	0.0000	0.3499	0.0000	-1.0000	0.0000	0.3499	0.0000	0.9368
+# Sample Name	Session Name	Index	Assoc. Target	Loc. X	Loc. Y	Loc. Z	m0n0	m0n1	m0n2	m1n0	m1n1	m1n2	m2n0	m2n1	m2n2	Dist. to Target	Target Error	Angular Error	Twist Error	Stim. Power A	Stim. Pulse Interval	Stim. Power B	Date	Time	Creation Cause	Crosshairs Driver	Chamber Name	Chamber Grid Name	Chamber IndexX	Chamber IndexY	Offset	Comment	EMG Channels	EMG Window Start	EMG Window End
+Sample 1	Session 1	1	(null)	3.2625	66.7014	56.0143	-1.0000	0.0000	0.0000	0.0000	-1.0000	0.0000	0.0000	0.0000	1.0000	(null)	(null)	(null)	(null)	(null)	(null)	(null)	2024-02-22	11:32:09.283	Button	Mouse	(null)	(null)	(null)	(null)	0.0000	(null)	(null)	(null)	(null)
+Sample 2	Session 1	2	(null)	3.2625	-7.9865	79.1648	-1.0000	0.0000	0.0000	0.0000	-1.0000	0.0000	0.0000	0.0000	1.0000	(null)	(null)	(null)	(null)	(null)	(null)	(null)	2024-02-22	11:32:11.941	Button	Mouse	(null)	(null)	(null)	(null)	0.0000	(null)	(null)	(null)	(null)
+Sample 3	Session 1	3	(null)	3.2625	-50.7047	20.7373	-1.0000	0.0000	0.0000	0.0000	-1.0000	0.0000	0.0000	0.0000	1.0000	(null)	(null)	(null)	(null)	(null)	(null)	(null)	2024-02-22	11:32:14.328	Button	Mouse	(null)	(null)	(null)	(null)	0.0000	(null)	(null)	(null)	(null)
+# Session Name	Loc. X	Loc. Y	Loc. Z	m0n0	m0n1	m0n2	m1n0	m1n1	m1n2	m2n0	m2n1	m2n2
+Session 1	(null)	(null)	(null)	(null)	(null)	(null)	(null)	(null)	(null)	(null)	(null)	(null)

--- a/simnibs/utils/tests/test_nnav.py
+++ b/simnibs/utils/tests/test_nnav.py
@@ -160,6 +160,15 @@ def nii_niftialigned_fn():
 
 
 @pytest.fixture()
+def nii_niftialigned_q_fn():
+    # Brainsight export for nifti file, nifti:aligned:q coordinate system
+    nii_fn = os.path.join(FIXTURE_DIR,
+                          "brainsight",
+                          "niiImage_niftialigned_q_coord_v14.txt".replace('/', os.sep))
+    return nii_fn
+
+
+@pytest.fixture()
 def nii_niftialigned_empty_fn():
     # Brainsight export for nifti file, nifti:aligned coordinate system
     # no targets, not samples
@@ -203,6 +212,14 @@ def arr_sample2():
                      [-1.3000e-02, 8.8300e-01, -4.6900e-01, 7.5810e+01],
                      [-7.0200e-01, -3.4200e-01, -6.2400e-01, 6.5742e+01],
                      [0.0000e+00, 0.0000e+00, 0.0000e+00, 1.0000e+00]])
+
+
+@pytest.fixture()
+def arr_sample3():
+    return np.array([[ 1.0,  0.0,  0.0,  3.2625],
+                     [ 0.0, -1.0,  0.0, 66.7014],
+                     [ 0.0,  0.0, -1.0, 56.0143],
+                     [ 0.0,  0.0,  0.0,  1.    ]])
 
 
 ## ANT test files and data ##
@@ -321,7 +338,7 @@ class TestBrainsight:
         with pytest.raises(ValueError):
             brainsight().read(nii_niftiscanner_fn)
 
-    # Only support for nifti:aligned
+    # Support for nifti:aligned until v13 Brainsight .txt files, and for nifit:aligned:q from v14.
 
     def test_read_dcm_niftialigned(self, dcm_niftialigned_fn, arr_sample1):
         tmslist_targets, tms_list_samples = brainsight().read(dcm_niftialigned_fn)
@@ -341,6 +358,16 @@ class TestBrainsight:
         assert len(tms_list_samples.pos) == 101
         assert tms_list_samples.pos[0].name == 'Sample 1'
         np.all(np.isclose(tms_list_samples.pos[0].matsimnibs, arr_sample2))
+
+
+    def test_read_nii_niftialigned_q(self, nii_niftialigned_q_fn, arr_sample3):
+        tmslist_targets, tms_list_samples = brainsight().read(nii_niftialigned_q_fn)
+        assert tmslist_targets.name == 'Targets'
+        assert tms_list_samples.name == 'Samples'
+        assert len(tmslist_targets.pos) == 2
+        assert len(tms_list_samples.pos) == 3
+        assert tms_list_samples.pos[0].name == 'Sample 1'
+        assert np.all(np.isclose(tms_list_samples.pos[0].matsimnibs, arr_sample3))
 
 
     def test_read_nii_niftialigned_empty(self, nii_niftialigned_empty_fn):


### PR DESCRIPTION
Currently SimNIBS supports importing Brainsight-exported .txt files when the `NIfTI:Aligned` coordinate system is used.

Starting with Brainsight 2.5.3 (to be released next week), we provide more detailed names for coordinate systems derived from NIfTI files, e.g. `NIfTI:Q:Aligned` to indicate that it is an 'aligned' coordinate space coming from the q-form.

This was necessary to avoid user confusion when using NIfTI files that provide both q-form and s-form coordinate spaces.

Note that a q-form coordinate system can be any of the following:
 - `NIfTI:Q:Scanner`
 - `NIfTI:Q:Aligned`
 - `NIfTI:Q:MNI-152`
 - `NIfTI:Q:Talairach`
 - `NIfTI:Q:Other-Template`

With these changes SimNIBS will import a .txt as long as the coordinate space name starts with `NIfTI:Q:`, in other words any of the above.

This PR adds support for the latest (v14) format of the Brainsight .txt files, while preserving old behaviour for all the .txt files generated until now (v13 and older).
