### PR TITLE
Adding notes about building on arm64 Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Please visit [the SimNIBS website](https://simnibs.github.io/simnibs/build/html/
 
 ## Installation for development
 
-After cloning the repository:
+After cloning the repository (for all platforms except arm64 Macs):
 
 ```
 conda env create -f environment_.yml -n <name_of_my_environment>
@@ -29,6 +29,11 @@ conda activate <name_of_my_environment>
 python -m pip install --editable .
 python simnibs/cli/link_external_progs.py
 ```
+
+NOTE: Currently on arm64 Macs it is only possible to build by creating an x86_64 environment. To do so, replace the first command above with:
+```
+conda env create -f environment_.yml -n <name_of_my_environment> --platform osx-64
+```  
 
 ## Authors
 Please see [the SimNIBS website](./docs/contributors.rst) for a complete list of contributors.

--- a/README.md
+++ b/README.md
@@ -30,10 +30,18 @@ python -m pip install --editable .
 python simnibs/cli/link_external_progs.py
 ```
 
-NOTE: Currently on arm64 Macs it is only possible to build by creating an x86_64 environment. To do so, replace the first command above with:
-```
-conda env create -f environment_.yml -n <name_of_my_environment> --platform osx-64
-```  
+> **NOTE**
+>
+> Currently on arm64 Macs it is only possible to build by creating an x86_64 environment. To do so, replace the first command above with:
+> ```
+> conda env create -f environment_.yml -n <name_of_my_environment> --platform osx-64
+> ```
+> If the `--platform` argument is not available in your version of `conda`, use
+> ```
+> CONDA_SUBDIR=osx-64 conda env create -f environment_.yml -n <name_of_my_environment>
+> conda env config vars set CONDA_SUBDIR=osx-64 -n <name_of_my_environment>
+> ```
+> The latter command ensures that new packages are also installed from the `osx-64` subdir in this environment.
 
 ## Authors
 Please see [the SimNIBS website](./docs/contributors.rst) for a complete list of contributors.

--- a/docs/installation/conda.rst
+++ b/docs/installation/conda.rst
@@ -78,11 +78,13 @@ MacOS
   .. code-block:: bash
 
       export PATH="$HOME/miniconda/bin:$PATH" # This part can change depending on your miniconda installation
-      conda env create -f ~/Downloads/environment_macOS.yml
+      conda env create -f ~/Downloads/environment_macOS.yml --platform osx-64
       conda activate simnibs_env
       pip install -f https://github.com/simnibs/simnibs/releases/latest simnibs
 
   \
+
+  NOTE: Currently on arm64 Macs it is only possible to build by creating an x86_64 environment.
 
 4. (Optional) To setup the menu icons, file associations, the MATLAB library and add SimNIBS to the system path, run the :code:`postinstall_simnibs` script:
 

--- a/docs/installation/conda.rst
+++ b/docs/installation/conda.rst
@@ -73,18 +73,39 @@ MacOS
 
 2. Download the `SimNIBS OSX environment file <https://github.com/simnibs/simnibs/releases/latest/download/environment_macOS.yml>`_
 
-3. Run in a terminal window:
+3. If you are using an Intel-based Mac (x86_64), run the following in a terminal window:
 
   .. code-block:: bash
+  
+      export PATH="$HOME/miniconda/bin:$PATH" # This part can change depending on your miniconda installation
+      conda env create -f ~/Downloads/environment_macOS.yml
+      conda activate simnibs_env
+      pip install -f https://github.com/simnibs/simnibs/releases/latest simnibs
+  
+  \
 
+If you are using an ARM-based Mac, you will have to create an x86_64 environment in order to build simnibs. Run this instead
+
+  .. code-block:: bash
+  
       export PATH="$HOME/miniconda/bin:$PATH" # This part can change depending on your miniconda installation
       conda env create -f ~/Downloads/environment_macOS.yml --platform osx-64
       conda activate simnibs_env
       pip install -f https://github.com/simnibs/simnibs/releases/latest simnibs
-
+  
   \
 
-  NOTE: Currently on arm64 Macs it is only possible to build by creating an x86_64 environment.
+If the :code:`--platform` argument is not available in your version of conda, use the following workaround
+  
+  .. code-block:: bash
+  
+      export PATH="$HOME/miniconda/bin:$PATH" # This part can change depending on your miniconda installation
+      CONDA_SUBDIR=osx-64 conda env create -f ~/Downloads/environment_macOS.yml
+      conda env config vars set CONDA_SUBDIR=osx-64 -n simnibs_env
+      conda activate simnibs_env
+      pip install -f https://github.com/simnibs/simnibs/releases/latest simnibs
+  
+  \
 
 4. (Optional) To setup the menu icons, file associations, the MATLAB library and add SimNIBS to the system path, run the :code:`postinstall_simnibs` script:
 


### PR DESCRIPTION
As you know there are two kind of Mac computers:
 - older Intel based (x86_64)
 - newer Apple Silicon based (arm64)

Generally the arm64 based Macs can also run x86_64 software (due to Rosetta2 translator), but not vice-versa.

Currently, on macOS, it is only possible to build the x86_64 version of SimNIBS.

These changes to the documentation add an extra parameter needed on arm64 Macs to make sure conda creates an x86_64 environment, as opposed to the default arm64 one.