### PR TITLE
Add workaround for ValueError when running charm --fs-dir

### DIFF
--- a/simnibs/segmentation/charm_main.py
+++ b/simnibs/segmentation/charm_main.py
@@ -856,7 +856,8 @@ def _load_freesurfer_pial_surface(fs_sub):
     # The pial surfaces (?h.pial) are symlinks to either ?h.pial.T1 or
     # ?h.pial.T2 depending on whether the `-T2pial` flag was used when
     # invoking recon-all. Symlinks created in WSL on Windows do not
-    # seem to work currently, hence this OSError and Value Error workaround
+    # seem to work currently, so this workaround handles both OSError
+    # and ValueError.
     try:
         m = load_freesurfer_surfaces(fs_sub, "pial", coord="ras")
     except (OSError, ValueError): # invalid argument


### PR DESCRIPTION
## What

In this code, when running ```charm --fs-dir```, a workaround (`except OSError:`) is implemented to handle cases where pial surface files created under WSL fail to function properly as symlinks and cause errors.

```python
def _load_freesurfer_pial_surface(fs_sub):
    # The pial surfaces (?h.pial) are symlinks to either ?h.pial.T1 or
    # ?h.pial.T2 depending on whether the `-T2pial` flag was used when
    # invoking recon-all. Symlinks created in WSL on Windows do not
    # seem to work currently, hence this workaround
    try:
        m = load_freesurfer_surfaces(fs_sub, "pial", coord="ras")
    except OSError: # invalid argument
        try:
            m = load_freesurfer_surfaces(fs_sub, "pial.T2", coord="ras")
        except FileNotFoundError: # -T2pial was not used
            m = load_freesurfer_surfaces(fs_sub, "pial.T1", coord="ras")
    return m
```

However, when I run it in my environment (SimNIBS 4.5 on Windows, FreeSurfer on WSL), I get the following error.

```
[ simnibs ] INFO: Ensure CSF
[ simnibs ] INFO: Starting surface creation
[ simnibs ] INFO: Using surfaces from FreeSurfer
[ simnibs ] INFO: FreeSurfer subject directory is C:\Users\***\***
[ simnibs ] CRITICAL: Uncaught exception
ValueError: File does not appear to be a Freesurfer surface
```

## Why
This error is caused by [nibabel.freesurfer.io.read_geometry](https://github.com/nipy/nibabel/blob/master/nibabel/freesurfer/io.py#L180) failing to load the pial file. However, since a `ValueError` is raised in this case, the previously mentioned workaround using `OSError` cannot handle it.

```python
with open(filepath, 'rb') as fobj:
    magic = _fread3(fobj)
    if magic in (QUAD_MAGIC, NEW_QUAD_MAGIC):  # Quad file
        ...
    elif magic == TRIANGLE_MAGIC:  # Triangle file
        ...
    else:
        raise ValueError('File does not appear to be a Freesurfer surface')
```

## How
I modified to also handle `ValueError`