### PR TITLE
Patch CGAL 5.6.1 headers to fix Clang 19+ build error on macOS ARM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@ import os
 import re
 import sys
 import shutil
+import fileinput
+from pathlib import Path
 from setuptools.command.build_ext import build_ext
 from distutils.dep_util import newer_group
 import numpy as np
@@ -42,6 +44,24 @@ is_conda = 'CONDA_PREFIX' in os.environ
 # No conda, no setup
 if not is_conda:
     raise Exception("Cannot run setup without conda")
+
+# Patch CGAL 5.6.1 headers to fix Clang 19+ compilation (remove obsolete this->base() calls)
+# This is needed until 5.6.2 is available through conda forge (if ever) or until it is possible to
+# rewrite _mesh_volumes.cpp (?, and potentially more) to match the newer CGAL >6. overloads
+def _patch_cgal_iterator():
+    """Replace obsolete this->base() with boost::get_pointer(*this)."""
+    hdr = Path(os.environ['CONDA_PREFIX']) / "include" / "CGAL" / "boost" / "graph" / "iterator.h"
+    if not hdr.exists():
+        return          # nothing to patch (non-Conda build)
+    txt = hdr.read_text()
+    if "this->base()" not in txt:   # already fixed or CGAL ≥6
+        return
+    bak = hdr.with_suffix(".bak3")
+    shutil.copy2(hdr, bak)
+    with fileinput.FileInput(hdr, inplace=True, backup=".bak_tmp") as f:
+        for line in f:
+            print(re.sub(r"\bthis->base\(\)", "boost::get_pointer(*this)", line), end="")
+
 
 #### Setup compilation arguments
 
@@ -214,6 +234,7 @@ class build_ext_(build_ext):
         Build the extension, download some dependencies and remove stuff from other OS
     '''
     def run(self):
+        _patch_cgal_iterator()  # apply CGAL iterator.h workaround if needed
         from Cython.Build import cythonize
         ## Cythonize
         self.extension = cythonize(self.extensions)


### PR DESCRIPTION
### Patch CGAL 5.6.1 headers for clang 19+ on macOS/Linux

---

### Why this is needed  
- `clang`/LLVM 19 removed the deprecated `iterator_adaptor::base()` accessor.  
- CGAL upstream fixed the breakage in **[PR #8330](https://github.com/CGAL/cgal/pull/8330)** by switching to `base_reference()` and friends.  
- Until that fix ships on `conda-forge` (≥ 5.6.2), we have to patch the header locally or `simnibs` fails to build on Apple Silicon and any modern Clang toolchain.

---

### What this PR does  
1. **Adds** a helper function in `setup.py`:

    ```python
    # Patch CGAL 5.6.1 headers to fix Clang 19+ compilation (remove obsolete this->base() calls)
    # This is needed until 5.6.2 is available through conda forge (if ever) or until it is possible to
    # rewrite _mesh_volumes.cpp (?, and potentially more) to match the newer CGAL >6. overloads
    def _patch_cgal_iterator():
        """Hot-patch CGAL 5.6.1 iterator.h for clang 19+."""
        hdr = Path(os.environ["CONDA_PREFIX"]) / "include" / "CGAL" / "boost" / "graph" / "iterator.h"
        if not hdr.exists():
            return  # running on a pre-patched CGAL
        text = hdr.read_text()
        if "this->base()" not in text:   # already fixed
            return
        hdr_backup = hdr.with_suffix(".bak_clang19")
        shutil.copy2(hdr, hdr_backup)
        hdr.write_text(text.replace("this->base()", "boost::get_pointer(*this)"))
    ```

2. **Calls** `_patch_cgal_iterator()` in the `build_ext.run()` step, so it applies automatically before compiling the C++ extensions.

3. **Documents** the workaround and why it’s needed until CGAL 5.6.2 or 6.x becomes viable.

---

### Why not CGAL 6.x yet?  
CGAL ≥ 6 introduces breaking changes to `Labeled_mesh_domain_3`, used in `_mesh_volumes.cpp`.  
Fixing this requires rewriting parts of the CGAL call chain using `Named_function_parameters`.

---

### Enables builds on/with
- ✅ macOS Sequoia 15.5 (24F74) / Apple M4 Pro / Apple Silicon (clang 19+)  
- ✅ `pip install --no-build-isolation --editable .`

---

### Cleanup path  
- Remove this patch once `cgal-cpp=5.6.2` or later (with back-fitted patch for compilation) is available via `conda-forge`.
- Long-term: support CGAL ≥ 6.

---

**Reference:**  
- [CGAL/cgal PR #8330: Fix clang/LLVM 19 compilation issue in iterator.h](https://github.com/CGAL/cgal/pull/8330)
