### PR TITLE
suggestion to increase robustness of readability on PCs

### DIFF
--- a/simnibs/matlab_tools/mesh_save_gmsh4.m
+++ b/simnibs/matlab_tools/mesh_save_gmsh4.m
@@ -71,9 +71,14 @@ end
 [~,~,extHlp] = fileparts(fn);
 if ~strcmpi(extHlp,'.msh')
     fn=[fn '.msh'];
-end;
+end
 
-fid=fopen(fn, 'W');
+if ~is_binary
+    % suggested fix for more robust file-reading on PCs
+    fid = fopen(fn, 'Wt');
+else
+    fid=fopen(fn, 'W');
+end
 
 %% write initial header
 fprintf(fid, '$MeshFormat\n');


### PR DESCRIPTION
Hi simnibs maintainers, 
Here's a small suggested patch to your matlab gmsh4 write code.
The context is the following: when writing (old-fashioned) ASCII .msh files in a Windows platform, omitting the 't' flag when opening the file for writing may lead to unexpected errors when reading the file in another application. I have noticed this when playing around when playing around with a compiled executable, in combination with FieldTrip (brainstorm's solution to use duneuro for EEG/MEG forward computations). In FieldTrip, we re-use your gmsh loading/saving code, and I thought it a good plan to suggest a fix at the source...