### PR TITLE
bug fix Issue. #601 - charm fails to generate eeg_positions/ if new surface if new surface is made above 1005

### DIFF
--- a/simnibs/segmentation/charm_main.py
+++ b/simnibs/segmentation/charm_main.py
@@ -563,6 +563,8 @@ def run(
         skin_care = mesh_settings["skin_care"]
         mmg_noinsert = mesh_settings["mmg_noinsert"]
 
+        logger.info(f"Using skin tag: {skin_tag}")
+        
         # Meshing
 
         debug_path = None
@@ -610,13 +612,14 @@ def run(
         for fn in cap_files:
             fn_out = os.path.splitext(os.path.basename(fn))[0]
             fn_out = os.path.join(sub_files.eeg_cap_folder, fn_out)
-            transformations.warp_coordinates(
+            transformations.warp_coordinates( 
                 fn,
                 sub_files.subpath,
                 transformation_direction="mni2subject",
                 out_name=fn_out + ".csv",
                 out_geo=fn_out + ".geo",
                 mesh_in=mesh,
+                skin_tag=skin_tag
             )
 
         logger.info("Write label image from mesh")


### PR DESCRIPTION
Based on Issue #601 


Adding a new layer (say a new skin layer above scalp/1005) breaks `eeg_positions/` when running charm. 

Minimal changes to pass in `settings.ini["mesh"]["skin_tag"]`, defaults to `skin_tag=1005` (as it has been previous to this commit). 

Please see Issue #601 for more information and if you need more info feel free to let me know. 

I tested and working on linux: 

```
Linux quser42 4.18.0-553.64.1.el8_10.x86_64
....
NAME="Red Hat Enterprise Linux"
VERSION="8.10 (Ootpa)"
....
Architecture:        x86_64
```